### PR TITLE
fix: persist real checkbox state in announce preference (#65)

### DIFF
--- a/static/js/announce.js
+++ b/static/js/announce.js
@@ -34,7 +34,12 @@ const announce = (() => {
 
       $checkbox.prop('checked', padcookie.getPref('ep_announce-enabled') === true)
           .on('change', () => {
-            padcookie.setPref('ep_announce-enabled', $checkbox.checked);
+            // `$checkbox` is a jQuery wrapper, not the raw DOM element, so
+            // `.checked` is always undefined — the preference was being
+            // written as `undefined` on every toggle (#65). Read the state
+            // through jQuery's `prop('checked')` so the real boolean lands
+            // in the cookie.
+            padcookie.setPref('ep_announce-enabled', $checkbox.prop('checked'));
           });
 
       const $label = $('<label for="ep_announce-enabled" data-l10n-id="pad.ep_announce.checkbox">' +


### PR DESCRIPTION
Fixes #65. The change handler wrote `$checkbox.checked` to the pad cookie, but `$checkbox` is a jQuery wrapper so `.checked` was always `undefined` — every toggle stored `undefined` instead of the real boolean. That's what made the existing cookies spec flake out with 'Checkbox not set to true'. Replace with `$checkbox.prop('checked')`. The existing `cookies.js` frontend spec already exercises this exact flow.