### PR TITLE
docs: add README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,20 @@ ep_announce
 `ep_announce` is an Etherpad-lite plugin that plays a chime when someone enters a pad. It is disabled by default, and can be enabled using a new switch on the user list panel. The setting is per-browser (stored in cookies).
 
 The chime will play if when new user joins after being absent for at least a few seconds. For instance, it won't play if a user merely refreshes the page.
+
+## Installation
+
+Install from the Etherpad admin UI (**Admin → Manage Plugins**,
+search for `ep_announce` and click *Install*), or from the Etherpad
+root directory:
+
+```sh
+pnpm run plugins install ep_announce
+```
+
+> ⚠️ Don't run `npm i` / `npm install` yourself from the Etherpad
+> source tree — Etherpad tracks installed plugins through its own
+> plugin-manager, and hand-editing `package.json` can leave the
+> server unable to start.
+
+After installing, restart Etherpad.


### PR DESCRIPTION
Many operators reach for `npm i ep_<plugin>` because the README doesn't document the install flow — but that bypasses Etherpad's plugin-manager and typically leaves the server unable to start (cf. ether/ep_table_of_contents#154). Add a short uniform Installation section pointing at the admin UI / `pnpm run plugins install` and explicitly warning against hand-editing `package.json`.