### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_announce/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_announce/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_announce/actions/workflows/test-and-release.yml)
 
-ep_announce
-=========
+# Pad Entry Chime for Etherpad
 
 `ep_announce` is an Etherpad-lite plugin that plays a chime when someone enters a pad. It is disabled by default, and can be enabled using a new switch on the user list panel. The setting is per-browser (stored in cookies).
 


### PR DESCRIPTION
Replace the placeholder `ep_announce` heading in README.md with "Pad Entry Chime for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.