### PR TITLE
ci: trigger release after Dependabot Automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,6 +2,12 @@ name: Dependabot Automerge
 permissions:
   contents: write
   pull-requests: write
+  # `actions: write` lets the post-merge step kick off Node.js Package on
+  # the default branch via `gh workflow run`. Without this, automerge'd
+  # PRs land on main but the on-push release job never fires (GitHub
+  # Actions intentionally suppresses on:push triggers when the push is
+  # authenticated with GITHUB_TOKEN).
+  actions: write
 on:
   workflow_run:
     workflows:
@@ -21,10 +27,20 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Automerge
+        id: automerge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_METHOD: squash
           MERGE_LABELS: ""
           MERGE_RETRY_SLEEP: "100000"
+
+      - name: Trigger release on default branch
+        # `pascalgn/automerge-action` exits 0 whether or not it merged. Skip
+        # the dispatch when nothing was actually merged so we don't kick a
+        # phantom release run on every Dependabot Automerge invocation.
+        if: steps.automerge.outputs.mergeResult == 'merged'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run test-and-release.yml --ref ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,5 +1,11 @@
 name: Node.js Package
-on: [push]
+on:
+  push:
+  # Invoked by automerge.yml after a Dependabot PR is merged. GitHub
+  # Actions doesn't fire on:push when the push is authored by GITHUB_TOKEN
+  # (the automerge action's only available identity), so without this
+  # dispatch trigger the release job never runs after auto-merges.
+  workflow_dispatch:
 
 # id-token: write must be granted here so the reusable npmpublish workflow
 # can request an OIDC token for npm trusted publishing.


### PR DESCRIPTION
## Why

Dependabot's setup-node@6 PR ([#113](https://github.com/ether/ep_announce/pull/113)) auto-merged at 2026-04-29T10:26 — but the post-merge `Node.js Package` workflow never fired. Latest tag is still v0.0.63 from the previous human merge. This is happening across ~70+ plugins org-wide.

## Root cause

GitHub Actions intentionally suppresses `on: push` when the push is authored by `GITHUB_TOKEN` (the only identity `pascalgn/automerge-action` has). Dependabot Automerge → push by `github-actions[bot]` → no workflow fires → no version bump → no npm publish.

## Fix

Two coupled changes:

- **`automerge.yml`** grows `actions: write` and a final step:
  ```yaml
  - name: Trigger release on default branch
    if: steps.automerge.outputs.mergeResult == 'merged'
    env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
    run: gh workflow run test-and-release.yml --ref ${{ github.event.repository.default_branch }}
  ```
  The gate on `mergeResult == 'merged'` keeps things quiet when the action runs but doesn't actually merge.

- **`test-and-release.yml`** grows a `workflow_dispatch:` trigger so the dispatch above has something to invoke. Existing `on: [push]` is preserved.

## Validation

- [ ] Once merged, next Dependabot bump should auto-merge AND publish a new patch version automatically.
- [x] No PAT needed — `GITHUB_TOKEN` with `actions: write` can dispatch workflows in the same repo.

If this works on ep_announce, the same patch propagates mechanically to every other ether/* plugin. ~70 PRs, scriptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)